### PR TITLE
fix: Fix context parameters when setting title

### DIFF
--- a/SDNodeJsSDKV2/com.mirabox.streamdock.demo.sdPlugin/propertyInspector/utils/action.js
+++ b/SDNodeJsSDKV2/com.mirabox.streamdock.demo.sdPlugin/propertyInspector/utils/action.js
@@ -38,7 +38,7 @@ WebSocket.prototype.setTitle = function (str, row = 0, num = 6) {
     }
     this.send(JSON.stringify({
         event: "setTitle",
-        context: $uuid,
+        context: $context,
         payload: {
             target: 0,
             title: newStr || str

--- a/SDVueSDK/vue/src/hooks/property.ts
+++ b/SDVueSDK/vue/src/hooks/property.ts
@@ -60,7 +60,7 @@ export const usePropertyStore = defineStore('propertyStore', () => {
     server.send(
       JSON.stringify({
         event: 'setTitle',
-        context: window.argv[1],
+        context: window.argv[4].context,
         payload: {
           title,
           target: 0


### PR DESCRIPTION
Replace `window.argv[1]` with `window.argv[4].context` and `$uuid` with `$context` to ensure the correct context parameters are used when setting the title.